### PR TITLE
Auto name detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Provides an `easy_breadcrumbs` view helper for automatically generating bootstra
 
 * It's able to properly generate the html for many different types of complex routes (See Below).
 * It only generates breadcrumbs for the routes you've defined, so if you have a route `/categories/10/contacts/5`, but haven't defined an index view route for `/categories`, that item will be left out.
+* It can automatically detect certain name attributes for specific resources.
 
 ## Installation
 
@@ -53,7 +54,26 @@ And last but not least, make sure you have bootstrap installed. You can install 
 
 ## Details
 
-Easy Breadcrumbs is able to handle a variety of complex routes. Here are some examples:
+**NEW: Auto Name Detection**
+
+Easy Breadcrumbs can now detect names for specific resources.
+```
+Path: /contacts/10
+Old Breadcrumb Format: Home > Contacts > Contact
+New Breadcrumb Format: Home > Contacts > Ada Lovelace
+```
+
+At the moment this only works around a strict set of parameters:
+  * There is an instance variable for the current route that matches the directory name
+    * So for a route of "/contacts/10" there would need to be a `@contact` variable
+  * That object is a hash
+  * That hash contains one of the following keys: `:name`, `:title`, `:subject`
+
+Otherwise it will use the previous default formatting. I'm currently working on making this much more flexible and also allowing for custom configuration.
+
+**Easy Breadcrumbs is able to handle a variety of complex routes.**
+
+Here are some examples:
 
 ### Simple path to page
 ```
@@ -114,11 +134,15 @@ Breadcrumb: Home > Categories > Category > Contacts > Contact > Edit Contact
 * Refactor and cleanup
   * Change `Breadcrumb` class to `Breadcrumbs`. This class will be responsible for the logic of which type of format to use for each breadcrumb
   * Create new `Breadcrumb` class. This class will be responsible for the implementation details of formatting each type of breadcrumb.
-  * Add version restictions for dependencies in gemspec
+  * Add version restrictions for dependencies in gemspec
+* Improve Auto Name Detection
+  * It should also be able to handle if the resources are custom objects and their attributes are accessed through instance methods like `Object#name`.
+* Allow for custom configuration of name attributes for resources
+  * Should be able to do something like `set :easy_breadcrumbs, user: :name, post: :title`
 * More robust spec suite
   * Explore more edge cases for both unit and integration tests
   * Eliminate repetition in specs
-  * Other developments gems that would help with this?
+  * Other development gems that would help with this?
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -111,11 +111,15 @@ Breadcrumb: Home > Categories > Category > Contacts > Contact > Edit Contact
 
 ## Road Map
 
-* Add configuration for showing individual resource name/title as breadcrumb (e.g. "Ada Lovelace") anchor text rather than resource type name (e.g. "Contact")
+* Refactor and cleanup
+  * Change `Breadcrumb` class to `Breadcrumbs`. This class will be responsible for the logic of which type of format to use for each breadcrumb
+  * Create new `Breadcrumb` class. This class will be responsible for the implementation details of formatting each type of breadcrumb.
+  * Add version restictions for dependencies in gemspec
+* More robust spec suite
+  * Explore more edge cases for both unit and integration tests
+  * Eliminate repetition in specs
+  * Other developments gems that would help with this?
 * Integration for Rails
-* A simple means of configuration for things like:
-  * Turning on and off specific routes
-  * Setting breadcrumb styles (maybe provide an option for a different framework like Foundation, or just provide a few different styling presets)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -111,13 +111,14 @@ Breadcrumb: Home > Categories > Category > Contacts > Contact > Edit Contact
 
 ## Road Map
 
-* Refactor
+* Refactor and cleanup
   * Change `Breadcrumb` class to `Breadcrumbs`. This class will be responsible for the logic of which type of format to use for each breadcrumb
   * Create new `Breadcrumb` class. This class will be responsible for the implementation details of formatting each type of breadcrumb.
-* Integration for Rails
-* A simple means of configuration for things like:
-  * Turning on and off specific routes
-  * Setting breadcrumb styles (maybe provide an option for a different framework like Foundation, or just provide a few different styling presets)
+  * Add version restictions for dependencies in gemspec
+* More robust spec suite
+  * Explore more edge cases for both unit and integration tests
+  * Eliminate repetition in specs
+  * Other developments gems that would help with this?
 
 ## Contributing
 

--- a/lib/easy_breadcrumbs/version.rb
+++ b/lib/easy_breadcrumbs/version.rb
@@ -1,3 +1,3 @@
 module EasyBreadcrumbs
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/lib/easy_breadcrumbs/version.rb
+++ b/lib/easy_breadcrumbs/version.rb
@@ -1,3 +1,3 @@
 module EasyBreadcrumbs
-  VERSION = "0.4.0"
+  VERSION = '0.4.0'
 end

--- a/spec/integration/classic_style_spec.rb
+++ b/spec/integration/classic_style_spec.rb
@@ -1,7 +1,12 @@
-require "spec_helper"
-require "sinatra"
+require 'spec_helper'
+require 'sinatra'
 
 get "/" do
+  easy_breadcrumbs
+end
+
+get "/categories/:id" do
+  @category = { name: "Acquaintances" }
   easy_breadcrumbs
 end
 
@@ -37,7 +42,20 @@ describe Sinatra::Application do
     expected_html = <<~HTML.chomp
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="/">Home</a></li>
+        <li class="breadcrumb-item"><a href="/categories/5">Category</a></li>
         <li class="breadcrumb-item active">Edit Category</li>
+      </ol>
+    HTML
+
+    expect(last_response.body).to include(expected_html)
+  end
+
+  it "should show specific name of resource if instance variable is set" do
+    get "/categories/5"
+    expected_html = <<~HTML.chomp
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/">Home</a></li>
+        <li class="breadcrumb-item active">Acquaintances</li>
       </ol>
     HTML
 

--- a/spec/integration/modular_style_spec.rb
+++ b/spec/integration/modular_style_spec.rb
@@ -1,10 +1,15 @@
-require "spec_helper"
-require "sinatra/base"
+require 'spec_helper'
+require 'sinatra/base'
 
 class Application < Sinatra::Base
   helpers Sinatra::EasyBreadcrumbs
 
   get "/" do
+    easy_breadcrumbs
+  end
+
+  get "/categories/:id" do
+    @category = { name: "Acquaintances" }
     easy_breadcrumbs
   end
 
@@ -41,7 +46,20 @@ describe Application do
     expected_html = <<~HTML.chomp
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="/">Home</a></li>
+        <li class="breadcrumb-item"><a href="/categories/5">Category</a></li>
         <li class="breadcrumb-item active">Edit Category</li>
+      </ol>
+    HTML
+
+    expect(last_response.body).to include(expected_html)
+  end
+
+  it "should show specific name of resource if instance variable is set" do
+    get "/categories/5"
+    expected_html = <<~HTML.chomp
+      <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="/">Home</a></li>
+        <li class="breadcrumb-item active">Acquaintances</li>
       </ol>
     HTML
 

--- a/spec/unit/easy_breadcrumbs_spec.rb
+++ b/spec/unit/easy_breadcrumbs_spec.rb
@@ -8,28 +8,31 @@ describe EasyBreadcrumbs do
   Breadcrumb = EasyBreadcrumbs::Breadcrumb
 
   describe Breadcrumb do
-    it "requires `request_path` and `routes` arguments on instantiation" do
+    it "requires an `options` argument on instantiation" do
       expect { Breadcrumb.new }.to raise_error(ArgumentError)
     end
 
-    before(:all) do
-      @routes = [ /\A\/\z/,
-                  /\A\/contacts\/new\z/,
-                  /\A\/contacts\/([^\/?#]+)\z/,
-                  /\A\/contacts\/([^\/?#]+)\/edit\z/,
-                  /\A\/categories\/new\z/,
-                  /\A\/categories\/([^\/?#]+)\z/,
-                  /\A\/about\z/, /\A\/contacts\z/,
-                  /\A\/categories\z/,
-                  /\A\/categories\/([^\/?#]+)\/contacts\z/,
-                  /\A\/categories\/([^\/?#]+)\/contacts\/([^\/?#]+)\z/,
-                  /\A\/categories\/([^\/?#]+)\/contacts\/([^\/?#]+)\/edit\z/ ]
+    def configure(path, routes = nil, view_variables = [])
+      routes ||= [ /\A\/\z/,
+                   /\A\/contacts\/new\z/,
+                   /\A\/contacts\/([^\/?#]+)\z/,
+                   /\A\/contacts\/([^\/?#]+)\/edit\z/,
+                   /\A\/categories\/new\z/,
+                   /\A\/categories\/([^\/?#]+)\z/,
+                   /\A\/about\z/, /\A\/contacts\z/,
+                   /\A\/categories\z/,
+                   /\A\/categories\/([^\/?#]+)\/contacts\z/,
+                   /\A\/categories\/([^\/?#]+)\/contacts\/([^\/?#]+)\z/,
+                   /\A\/categories\/([^\/?#]+)\/contacts\/([^\/?#]+)\/edit\z/ ]
+      { request_path: path,
+        route_matchers: routes,
+        view_variables: view_variables }
     end
 
     describe "#to_html" do
       it "has single unlinked breadcrumb if page is home" do
-        request_path = "/"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item active">Home</li>
@@ -39,8 +42,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for simple path" do
-        request_path = "/about"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/about")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -51,8 +54,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to resource index page" do
-        request_path = "/contacts"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/contacts")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -63,8 +66,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to specific resource" do
-        request_path = "/contacts/28"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/contacts/28")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -76,8 +79,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to resource new view" do
-        request_path = "/contacts/new"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/contacts/new")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -89,8 +92,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to edit specific resource" do
-        request_path = "/contacts/28/edit"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/contacts/28/edit")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -103,8 +106,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to nested resource index page" do
-        request_path = "/categories/5/contacts"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/categories/5/contacts")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -117,8 +120,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to specific nested resource" do
-        request_path = "/categories/5/contacts/10"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/categories/5/contacts/10")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -132,8 +135,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to nested resource new view" do
-        request_path = "/categories/5/contacts/new"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/categories/5/contacts/new")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -147,8 +150,8 @@ describe EasyBreadcrumbs do
       end
 
       it "returns proper html for path to edit specific nested resource" do
-        request_path = "/categories/5/contacts/10/edit"
-        breadcrumb_html = Breadcrumb.new(request_path, @routes).to_html
+        config = configure("/categories/5/contacts/10/edit")
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
@@ -166,13 +169,14 @@ describe EasyBreadcrumbs do
         routes = [ /\A\/categories\/([^\/?#]+)\z/,
                    /\A\/categories\/([^\/?#]+)\/contacts\/([^\/?#]+)\z/,
                    /\A\/categories\/([^\/?#]+)\/contacts\/([^\/?#]+)\/edit\z/ ]
-        request_path = "/categories/5/contacts/10/edit"
-        breadcrumb_html = Breadcrumb.new(request_path, routes).to_html
+        view_variables = [{:name => :contact, :value => {:name=>"Eli"}}]
+        config = configure("/categories/5/contacts/10/edit", routes, view_variables)                   
+        breadcrumb_html = Breadcrumb.new(config).to_html
         expected_html = <<~HTML.chomp
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/">Home</a></li>
             <li class="breadcrumb-item"><a href="/categories/5">Category</a></li>
-            <li class="breadcrumb-item"><a href="/categories/5/contacts/10">Contact</a></li>
+            <li class="breadcrumb-item"><a href="/categories/5/contacts/10">Eli</a></li>
             <li class="breadcrumb-item active">Edit Contact</li>
           </ol>
         HTML


### PR DESCRIPTION
## Auto Name Detection

Added automatic detection of name attribute for specific resource breadcrumb text

**Example:**
  - Old format: `Contacts > Contact`
  - New format: `Contacts > Ada Lovelace`

At the moment this only works around a strict set of parameters:
  * There is an instance variable for the current route that matches the directory name
    * So for a route of "/contacts/10" there would need to be a `@contact` variable
  * That object is a hash
  * That hash contains one of the following keys: `:name`, `:title`, `:subject`

Otherwise it will default to the previous format.

### Specs have been updated accordingly