### PR TITLE
Fix Issue #5

### DIFF
--- a/lib/easy_breadcrumbs/directory.rb
+++ b/lib/easy_breadcrumbs/directory.rb
@@ -10,24 +10,24 @@ module EasyBreadcrumbs
       @index = data.fetch(:index)
     end
 
-    def root_path?
-      index.zero?
-    end
-
     def ends_in_digit?
       name =~ %r{\d+\/?$}
     end
 
+    def new_or_edit_view?
+      new_view? || edit_view?
+    end
+
     def new_view?
-      name == 'new'
+      name == 'new' && nested?
     end
 
     def edit_view?
-      name == 'edit'
+      name == 'edit' && nested?
     end
 
-    def new_or_edit_view?
-      new_view? || edit_view?
+    def nested?
+      index > 0
     end
   end
 end

--- a/spec/unit/easy_breadcrumbs_spec.rb
+++ b/spec/unit/easy_breadcrumbs_spec.rb
@@ -281,6 +281,30 @@ describe EasyBreadcrumbs do
         expect(breadcrumb_html).to eq(expected_html)
       end
 
+      it "doesn't prefix anchor for top level /new directory with 'New'" do
+        config = configure(path: "/new")
+        breadcrumb_html = Breadcrumbs.new(config).to_html
+        expected_html = <<~HTML.chomp
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active">New</li>
+          </ol>
+        HTML
+        expect(breadcrumb_html).to eq(expected_html)
+      end
+
+      it "doesn't prefix anchor for top level /edit directory with 'Edit'" do
+        config = configure(path: "/edit")
+        breadcrumb_html = Breadcrumbs.new(config).to_html
+        expected_html = <<~HTML.chomp
+          <ol class="breadcrumb">
+            <li class="breadcrumb-item"><a href="/">Home</a></li>
+            <li class="breadcrumb-item active">Edit</li>
+          </ol>
+        HTML
+        expect(breadcrumb_html).to eq(expected_html)
+      end
+
       def configure(options)
         path = options.fetch(:path, "/")
         routes = options.fetch(:routes, default_routes)
@@ -307,6 +331,8 @@ describe EasyBreadcrumbs do
 
       def default_routes
         [/\A\/\z/,
+         /\A\/new\z/,
+         /\A\/edit\z/,
          /\A\/contacts\/new\z/,
          /\A\/contacts\/([^\/?#]+)\z/,
          /\A\/contacts\/([^\/?#]+)\/edit\z/,


### PR DESCRIPTION
### Issue Description
Defining 'new' route directly below top level causes the directory name to be output twice.

### Solution
* Changed the `Directory#new_view?` and `Directory#edit_view?` methods to also check and make sure the directory is nested and not directly below the top level.
* Updated Tests accordingly.